### PR TITLE
fixed get response for profile/cart

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -185,7 +185,6 @@ class Profile(ViewSet):
                 cart = {}
                 cart["order"] = OrderSerializer(open_order, many=False, context={
                                                 'request': request}).data
-                cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- bangazonapi/views/profile.py
- removed line 188 cart["order"]["line_items"] = line_items.data which was causing two sets of line items to show in GET call

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

{
    "id": 9,
    "url": "http://localhost:8000/orders/9",
    "created_date": "2018-12-08",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/6",
    "lineitems": [
        {
            "id": 1,
            "product": {
                "id": 1,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "Onguday",
                "image_path": null,
                "average_rating": 0
            }
        }
    ],
    "size": 1
}

## Testing

Description of how to test code...

- [ ] git fetch all
- [ ] git ticket-24-duplicate-line-items
- [ ] Put a valid token into authorization key in headers on Postman
- [ ] Put http://localhost:8000/profile/cart on a GET to test if duplicate line_items key is gone and just shows "lineitems".


## Related Issues

- Fixes #24 