### PR TITLE
fixed number_sold custom property bug

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -268,7 +268,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- bangazonapi/views/product.py
- changed line 271 from 
if product.number_sold <= int(number_sold):
- to: 
if product.number_sold >= int(number_sold):

## Testing

Description of how to test code...

- [ ] git fetch all
- [ ] git ticket-21-number-sold
- [ ] Run GET http://localhost:8000/products?number_sold=20 in Postman
- [ ] Should only show orders with number_sold of 20 or more


## Related Issues

- Fixes #21 