### PR TITLE
added location query to product list function

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -251,6 +251,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         min_price = self.request.query_params.get('min_price', None)
+        location = self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -281,6 +282,9 @@ class Products(ViewSet):
                     return True
                 return False
             products = filter(price_filter, products)
+
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- bangazonapi/views/product.py
- Added:
- Line 254: location = self.request.query_params.get('location', None)
- Line 286-287:
if location is not None:
            products = products.filter(location__contains=location)

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/products?location={location}` Gets all products with that location

## Testing

Description of how to test code...

- [ ] git fetch all
- [ ] git ticket-14-products-by-location
- [ ] Run http://localhost:8000/products?location={location} in Postman and check if only products with that location are showing

## Related Issues

- Fixes #14 